### PR TITLE
replaced uc_gui_click_captcha with sleep

### DIFF
--- a/app/services/pdf.py
+++ b/app/services/pdf.py
@@ -89,7 +89,7 @@ See file at:
 
         with SB(uc=True) as sb:
             sb.activate_cdp_mode(url=webpage_url)
-            sb.uc_gui_click_captcha()
+            sb.sleep(1)
             # sb.uc_gui_click_cf()
             # sb.uc_gui_click_rc()
             # TODO: there are some issues with indeed.com redirecting upon opening the print dialog.


### PR DESCRIPTION
It appears that `uc_gui_click_captcha` is now baked into `activate_cdp_mode` when it includes a URL argument. Unfortunately, I wasn't able to confirm this in the source code.